### PR TITLE
Updated AWS Tagging example to support Aurora.

### DIFF
--- a/AWS/RecommendedPolicies/PMC-AWS-Policy-with-tagging.json
+++ b/AWS/RecommendedPolicies/PMC-AWS-Policy-with-tagging.json
@@ -55,14 +55,26 @@
             "Sid": "AllowTaggedRDSOnly",
             "Action": [
                 "rds:ModifyDBInstance",
-                "rds:StartDBCluster",
                 "rds:StartDBInstance",
-                "rds:StopDBCluster",
                 "rds:StopDBInstance"
             ],
             "Condition": {
                 "StringEquals": {
                     "rds:db-tag/parkmycloud": "yes"
+                }
+            },
+            "Resource": "*",
+            "Effect": "Allow"
+        },
+        {
+            "Sid": "AllowTaggedRDSAuroraOnly",
+            "Action": [
+                "rds:StartDBCluster",
+                "rds:StopDBCluster"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "rds:cluster-tag/parkmycloud": "yes"
                 }
             },
             "Resource": "*",


### PR DESCRIPTION
`rds:db-tag` can't be used as a condition for allowing the rds cluster actions. The `rds:cluster-tag` should be used instead.

Steps to test this change:

1. Tag an Aurora cluster with "parkmycloud:yes"
2. Using the existing `PMC-AWS-Policy-with-tagging.json`, attempt to schedule the cluster
    * I was attempting a stop, but either operation should fail.

This will generate an alert in the PMC console: 

```
error stopping instance: Cloud provider denied access for this operation: StopDbDBInstance, AccessDenied: User: arn:aws:sts::<account_id>:assumed-role/<role_name>/pmc_session is not authorized to perform: rds:StopDBCluster on resource: <cluster ARN> status code: 403, request id: 594ddc72-0355-4834-809a-13eefc9d4e99
```

Applying the change in the PR resolves this issue and allows the cluster to be scheduled properly.